### PR TITLE
Proposed fix for the CPANTESTER fail report.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -46,7 +46,7 @@ JSON::MaybeXS               = 0
 Test2::Bundle::Extended 	= 0
 Test2::Tools::Explain 		= 0
 Test2::Plugin::NoWarnings 	= 0
-Test::MockModule            = 0
+Test::MockModule            = 0.13
 File::Temp                  = 0
 
 [TestRelease]


### PR DESCRIPTION
Hi @atoomic 

Please review the PR.

It propose the fix to the following FAIL report.
https://www.cpantesters.org/cpan/report/87d7d02c-4b9f-11e9-ab38-256e1f24ea8f

          Can't locate object method "redefine" via package "Test::MockModule" at t/hooks.t line 23.
          t/hooks.t .............. 

According to the Test::MockModule, Change file, it seems the method redefine() was introduced in v0.13.
https://metacpan.org/changes/distribution/Test-MockModule

          v0.13
          - Added the `redefine()` function. It works just like `mock()`, except if the
          method being mocked doesn't exist, it causes a panic. Many thanks to Felipe
          Gasper for this feature!

Many Thanks.
Best Regards,
Mohammad S Anwar